### PR TITLE
Added steps to build_test_and_push_to_codecov to kick off app store deploys - DC

### DIFF
--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build_test_and_push_to_codecov:
+  build_test_push_to_codecov_and_deploy:
     runs-on: ubuntu-latest
 
     steps:
@@ -47,3 +47,19 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ChopinDavid/grammatika
+
+      - name: Trigger build_and_upload_to_google_play
+        run: |
+          curl -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/actions/workflows/workflow_dispatch.yml/dispatches \
+          -d '{"ref":"main","inputs":{"job":"build_and_upload_to_google_play"}}'
+
+      - name: Trigger build_and_upload_to_app_store_connect
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/workflow_dispatch.yml/dispatches \
+            -d '{"ref":"main","inputs":{"job":"build_and_upload_to_app_store_connect"}}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Updated workflows to kick off deploys automatically
+
 ## 1.0.0
 
 * Initial release

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
This would close #8.